### PR TITLE
Validate loading paths

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -79,5 +79,6 @@ def load_decks_from_csv(directory: str) -> List[Deck]:
         filepath = os.path.join(directory, filename)
         if is_safe_path(directory, filepath) and is_valid_filename(filename):
             deck = load_deck_from_csv(filepath)
+            deck.is_modified = False
             decks.append(deck)
     return decks

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,19 @@ from models.Flashcard import Flashcard
 
 def is_valid_filename(filename: str) -> bool:
     # Filename can only include alphanumeric characters, dashes, and hyphens, and must end with .csv
-    return re.match(r'^[\w-]+\.csv$', filename) is not None
+    return re.match(r'^[\w\s-]+\.csv$', filename) is not None
+
+
+def is_safe_path(basedir, path, follow_symlinks=True):
+    if follow_symlinks:
+        abs_path = os.path.abspath(path)
+    else:
+        abs_path = os.path.realpath(path)
+
+    basedir = os.path.abspath(basedir)
+
+    # Ensure the abs_path starts with basedir and that the next character is a path separator
+    return abs_path.startswith(os.path.join(basedir, ''))
 
 
 def save_deck_to_csv(deck: Deck, directory: str) -> None:
@@ -64,7 +76,8 @@ def load_deck_from_csv(filename: str) -> Deck:
 def load_decks_from_csv(directory: str) -> List[Deck]:
     decks = []
     for filename in os.listdir(directory):
-        if filename.endswith(".csv"):
-            deck = load_deck_from_csv(f"{directory}/{filename}")
+        filepath = os.path.join(directory, filename)
+        if is_safe_path(directory, filepath) and is_valid_filename(filename):
+            deck = load_deck_from_csv(filepath)
             decks.append(deck)
     return decks

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,16 @@
 import os
+import re
 import csv
+
 from typing import List
 
 from models.Deck import Deck
 from models.Flashcard import Flashcard
+
+
+def is_valid_filename(filename: str) -> bool:
+    # Filename can only include alphanumeric characters, dashes, and hyphens, and must end with .csv
+    return re.match(r'^[\w-]+\.csv$', filename) is not None
 
 
 def save_deck_to_csv(deck: Deck, directory: str) -> None:

--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,7 @@ def is_valid_filename(filename: str) -> bool:
     return re.match(r'^[\w\s-]+\.csv$', filename) is not None
 
 
-def is_safe_path(basedir, path, follow_symlinks=True):
+def is_valid_path(basedir, path, follow_symlinks=True):
     if follow_symlinks:
         abs_path = os.path.abspath(path)
     else:
@@ -77,7 +77,7 @@ def load_decks_from_csv(directory: str) -> List[Deck]:
     decks = []
     for filename in os.listdir(directory):
         filepath = os.path.join(directory, filename)
-        if is_safe_path(directory, filepath) and is_valid_filename(filename):
+        if is_valid_path(directory, filepath) and is_valid_filename(filename):
             deck = load_deck_from_csv(filepath)
             deck.is_modified = False
             decks.append(deck)


### PR DESCRIPTION
Closes #16 
- Added two helper functions
  - One to validate filenames. Filenames can include alphanumeric characters, spaces, dashes, and hyphens, and must end in .csv
  - Another to validate file paths when loading decks
- Updated the load_decks_from_csv() function to use these helper functions and to set the loaded decks' is_modified flags to False so they aren't saved more than necessary