### PR TITLE
Add keyboard shortcuts

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,14 +41,17 @@ class MainWindow(QWidget):
         # After clicking a "Add card" button, the AddCardWidget will be displayed
         self.button_layout = QHBoxLayout()
         self.add_card_button = QPushButton("Add Card")
+        self.add_card_button.tool_tip = "Shortcut: Ctrl+N"
         self.add_card_button.clicked.connect(self.show_add_card_widget)
         self.button_layout.add_widget(self.add_card_button)
 
         self.add_deck_button = QPushButton("Add Deck")
+        self.add_deck_button.tool_tip = "Shortcut: Ctrl+D"
         self.add_deck_button.clicked.connect(self.show_add_deck_widget)
         self.button_layout.add_widget(self.add_deck_button)
 
         self.save_button = QPushButton("Save")
+        self.save_button.tool_tip = "Shortcut: Ctrl+S"
         self.save_button.clicked.connect(lambda: utils.save_decks_to_csv(app_decks, "decks"))
         self.button_layout.add_widget(self.save_button)
 

--- a/main.py
+++ b/main.py
@@ -84,7 +84,10 @@ class MainWindow(QWidget):
 
     def setup_shortcuts(self):
         shortcuts = {
-            "Ctrl+S": lambda: utils.save_decks_to_csv(app_decks, "decks")
+            "Ctrl+S": lambda: utils.save_decks_to_csv(app_decks, "decks"),
+            "Ctrl+N": self.show_add_card_widget,
+            "Ctrl+D": self.show_add_deck_widget,
+            "Ctrl+Q": self.close
         }
 
         for key_sequence, action in shortcuts.items():

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtGui import QFont
+from PySide6.QtGui import QFont, QKeySequence, QShortcut
 from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property
@@ -54,6 +54,8 @@ class MainWindow(QWidget):
 
         self.layout.add_layout(self.button_layout)
 
+        self.setup_shortcuts()
+
         self.set_layout(self.layout)
 
         self.window_title = "JLPyT Flashcards"
@@ -79,6 +81,15 @@ class MainWindow(QWidget):
         self.layout.replace_widget(self.deck_list_widget, new_deck_list_widget)
         self.deck_list_widget.delete_later()
         self.deck_list_widget = new_deck_list_widget
+
+    def setup_shortcuts(self):
+        shortcuts = {
+            "Ctrl+S": lambda: utils.save_decks_to_csv(app_decks, "decks")
+        }
+
+        for key_sequence, action in shortcuts.items():
+            shortcut = QShortcut(QKeySequence(key_sequence), self)
+            shortcut.activated.connect(action)
 
 
 main_window = MainWindow()

--- a/widgets/AddCardWidget.py
+++ b/widgets/AddCardWidget.py
@@ -1,3 +1,4 @@
+from PySide6.QtGui import QShortcut, QKeySequence
 from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox
 from PySide6.QtCore import Qt, Slot
 
@@ -29,22 +30,27 @@ class AddCardWidget(QWidget):
         self.question_label = QLabel("Front:")
         self.layout.add_widget(self.question_label)
         self.question_input = QLineEdit()
+        self.question_input.returnPressed.connect(self.add_card)
         self.layout.add_widget(self.question_input)
 
         self.answer_label = QLabel("Back:")
         self.layout.add_widget(self.answer_label)
         self.answer_input = QLineEdit()
+        self.answer_input.returnPressed.connect(self.add_card)
         self.layout.add_widget(self.answer_input)
 
         self.tags_label = QLabel("Tags (seperate by spaces):")
         self.layout.add_widget(self.tags_label)
         self.tags_input = QLineEdit()
+        self.tags_input.returnPressed.connect(self.add_card)
         self.layout.add_widget(self.tags_input)
 
         self.add_card_button = QPushButton("Add Card")
+        self.add_card_button.tool_tip = "Shortcut: Enter"
         self.add_card_button.clicked.connect(self.add_card)
         self.layout.add_widget(self.add_card_button)
 
+        self.setup_shortcuts()
         self.set_layout(self.layout)
         self.resize(400, 300)
         self.show()
@@ -62,3 +68,13 @@ class AddCardWidget(QWidget):
                 deck.append_card(Flashcard(question, answer, tags=tags))
                 break
         self.close()
+
+    def setup_shortcuts(self):
+        """This method sets up the keyboard shortcuts for the AddCardWidget"""
+        shortcuts = {
+            "Esc": self.close
+        }
+
+        for key_sequence, action in shortcuts.items():
+            shortcut = QShortcut(QKeySequence(key_sequence), self)
+            shortcut.activated.connect(action)

--- a/widgets/AddDeckWidget.py
+++ b/widgets/AddDeckWidget.py
@@ -36,6 +36,7 @@ class AddDeckWidget(QWidget):
         self.deck_name_label = QLabel("Deck Name:")
         form_layout.add_widget(self.deck_name_label)
         self.deck_name_input = QLineEdit()
+
         # Can't use "Enter" as a shortcut because of the way QLineEdit handles the "Enter" key, so we connect the
         # return_pressed signal to the add_deck method instead
         self.deck_name_input.returnPressed.connect(self.add_deck)

--- a/widgets/AddDeckWidget.py
+++ b/widgets/AddDeckWidget.py
@@ -1,3 +1,4 @@
+from PySide6.QtGui import QShortcut, QKeySequence
 from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit
 from PySide6.QtCore import Qt, Slot, Signal, QObject
 
@@ -35,6 +36,9 @@ class AddDeckWidget(QWidget):
         self.deck_name_label = QLabel("Deck Name:")
         form_layout.add_widget(self.deck_name_label)
         self.deck_name_input = QLineEdit()
+        # Can't use "Enter" as a shortcut because of the way QLineEdit handles the "Enter" key, so we connect the
+        # return_pressed signal to the add_deck method instead
+        self.deck_name_input.returnPressed.connect(self.add_deck)
         form_layout.add_widget(self.deck_name_input)
         self.layout.add_layout(form_layout)
 
@@ -42,6 +46,7 @@ class AddDeckWidget(QWidget):
         self.add_deck_button.clicked.connect(self.add_deck)
         self.layout.add_widget(self.add_deck_button)
 
+        self.setup_shortcuts()
         self.set_layout(self.layout)
         self.resize(400, 300)
         self.show()
@@ -54,3 +59,13 @@ class AddDeckWidget(QWidget):
 
         self.signals.deck_added.emit()
         self.close()
+
+    def setup_shortcuts(self):
+        """ This method sets up the keyboard shortcuts for the AddDeckWidget """
+        shortcuts = {
+            "Esc": self.close
+        }
+
+        for key_sequence, action in shortcuts.items():
+            shortcut = QShortcut(QKeySequence(key_sequence), self)
+            shortcut.activated.connect(action)

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -1,5 +1,6 @@
 from typing import List
 
+from PySide6.QtGui import QShortcut, QKeySequence
 from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QStackedWidget
 from PySide6.QtCore import Qt, Slot
 
@@ -44,6 +45,9 @@ class DeckListWidget(QWidget):
         # Add the deck list widget to the stacked widget
         self.stacked_widget.add_widget(self.deck_list_widget)
         self.layout.add_widget(self.stacked_widget)
+
+        self.setup_shortcuts()
+
         self.set_layout(self.layout)
 
     @Slot()
@@ -60,6 +64,7 @@ class DeckListWidget(QWidget):
 
         # Create a back button to return to the deck list
         back_button = QPushButton("Back")
+        back_button.tool_tip = "Shortcut: Esc"
         back_button.clicked.connect(lambda: self.stacked_widget.set_current_widget(self.deck_list_widget))
 
         # Add the back button and card widget to the flashcard layout
@@ -67,3 +72,13 @@ class DeckListWidget(QWidget):
         flashcard_layout.add_widget(card_widget)
         self.stacked_widget.add_widget(flashcard_layout_widget)
         self.stacked_widget.set_current_widget(flashcard_layout_widget)
+
+    def setup_shortcuts(self):
+        """ This method sets up the keyboard shortcuts for the DeckListWidget. """
+        shortcuts = {
+            "Esc": lambda: self.stacked_widget.set_current_widget(self.deck_list_widget)
+        }
+
+        for key_sequence, action in shortcuts.items():
+            shortcut = QShortcut(QKeySequence(key_sequence), self)
+            shortcut.activated.connect(action)


### PR DESCRIPTION
### Closes #34 for now
Now users have shortcuts that they can use on each different widget so far. They can add cards/decks, save their progress, exit screens, and close the app using shortcuts. As more functionality is added, it'll be good to keep updating the shortcuts along with it.

One thing that might need to be refactored is that currently, each widget has some variation of a setup_shortcuts() method that they call, and so that method is defined 5 different times at this point. It would probably be better to change it so that the setup_shortcuts() method is in the utils.py file, and maybe change the definition to something like the following

`def setup_shortcuts(context: QWidget, shortcuts: dict):
    pass`

And then in the AddCardWidget, for example, calling it like so:
`utils.setup_shortcuts(context=self, shortcuts={"Esc": self.close})`