### PR TITLE
Ensure fields are required

### DIFF
--- a/widgets/AddCardWidget.py
+++ b/widgets/AddCardWidget.py
@@ -1,5 +1,6 @@
 from PySide6.QtGui import QShortcut, QKeySequence
-from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QDialog
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QDialog, \
+    QMessageBox
 from PySide6.QtCore import Qt, Slot
 
 # noinspection PyUnresolvedReference
@@ -64,20 +65,14 @@ class AddCardWidget(QWidget):
         deck_name = self.deck_dropdown.current_text
         question = self.question_input.text
         if not question:
-            error_dialog = QDialog()
-            error_dialog.window_title = "Error"
-            error_dialog.layout = QVBoxLayout()
-            error_label = QLabel('"Front" field cannot be blank.')
-            error_dialog.layout.add_widget(error_label)
-            ok_button = QPushButton("OK")
-            ok_button.clicked.connect(error_dialog.close)
-            error_dialog.layout.add_widget(ok_button)
+            error_msg = QMessageBox()
+            error_msg.text = 'The "Front" field cannot be blank.'
+            error_msg.icon = QMessageBox.Warning
+            error_msg.standard_buttons = QMessageBox.Ok
 
-            shortcut_exit = QShortcut("Esc", error_dialog)
-            shortcut_exit.activated.connect(error_dialog.close)
-
-            error_dialog.set_layout(error_dialog.layout)
-            error_dialog.exec_()
+            shortcut_exit = QShortcut(QKeySequence("Esc"), error_msg)
+            shortcut_exit.activated.connect(error_msg.close)
+            error_msg.exec_()
             return
         answer = self.answer_input.text
         tags = self.tags_input.text.split(' ')

--- a/widgets/AddCardWidget.py
+++ b/widgets/AddCardWidget.py
@@ -1,5 +1,5 @@
 from PySide6.QtGui import QShortcut, QKeySequence
-from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QComboBox, QDialog
 from PySide6.QtCore import Qt, Slot
 
 # noinspection PyUnresolvedReference
@@ -63,6 +63,22 @@ class AddCardWidget(QWidget):
         """This method adds a new card to the selected deck"""
         deck_name = self.deck_dropdown.current_text
         question = self.question_input.text
+        if not question:
+            error_dialog = QDialog()
+            error_dialog.window_title = "Error"
+            error_dialog.layout = QVBoxLayout()
+            error_label = QLabel('"Front" field cannot be blank.')
+            error_dialog.layout.add_widget(error_label)
+            ok_button = QPushButton("OK")
+            ok_button.clicked.connect(error_dialog.close)
+            error_dialog.layout.add_widget(ok_button)
+
+            shortcut_exit = QShortcut("Esc", error_dialog)
+            shortcut_exit.activated.connect(error_dialog.close)
+
+            error_dialog.set_layout(error_dialog.layout)
+            error_dialog.exec_()
+            return
         answer = self.answer_input.text
         tags = self.tags_input.text.split(' ')
 

--- a/widgets/AddDeckWidget.py
+++ b/widgets/AddDeckWidget.py
@@ -1,5 +1,5 @@
 from PySide6.QtGui import QShortcut, QKeySequence
-from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QMessageBox
 from PySide6.QtCore import Qt, Slot, Signal, QObject
 
 # noinspection PyUnresolvedReference
@@ -59,6 +59,14 @@ class AddDeckWidget(QWidget):
     def add_deck(self):
         """ This method adds a new deck to the deck list widget """
         deck_name = self.deck_name_input.text
+        if not deck_name:
+            error_msg = QMessageBox()
+            error_msg.text = "The deck name field cannot be blank."
+            error_msg.icon = QMessageBox.Warning
+            error_msg.standard_buttons = QMessageBox.Ok
+            error_msg.exec_()
+
+            return
         self.deck_list_widget.decks.append(Deck(deck_name, []))
 
         self.signals.deck_added.emit()

--- a/widgets/AddDeckWidget.py
+++ b/widgets/AddDeckWidget.py
@@ -64,6 +64,9 @@ class AddDeckWidget(QWidget):
             error_msg.text = "The deck name field cannot be blank."
             error_msg.icon = QMessageBox.Warning
             error_msg.standard_buttons = QMessageBox.Ok
+
+            shortcut_exit = QShortcut(QKeySequence("Esc"), error_msg)
+            shortcut_exit.activated.connect(error_msg.close)
             error_msg.exec_()
 
             return


### PR DESCRIPTION
### Closes #35 and includes adding Cards as well
- If a user attempts to add a deck without a name, a warning message box pops up and they have to acknowledge the message before going back to the AddDeckWidget. 
- If a user attempts to add a card without an entry in the "Front" field, a warning message box pops up. However, the only required field for cards is the "Front" field, so users can create cards with only a front, and no back or tags.

I think that in the AddCardWidget, the QComboBox that holds the deck options already prevents users from selecting an "empty" deck, but it might still be worth ensuring that the deck name selection isn't empty. 