### PR TITLE
Change to qtreewidget for browser

### DIFF
--- a/models/Flashcard.py
+++ b/models/Flashcard.py
@@ -91,7 +91,7 @@ class Flashcard:
         return f"Question: {self.question}\nAnswer: {self.answer}\nNext Review Date: {self.next_review_date}"
 
     def __eq__(self, other):
-        return self.question == other.question and self.answer == other.answer
+        return (self.question == other.question and self.answer == other.answer) or self.id == other.id
 
     def __ne__(self, other):
         return not self == other
@@ -110,3 +110,6 @@ class Flashcard:
 
     def __repr__(self):
         return f"Flashcard({self.question}, {self.answer}, {self.next_review_date})"
+
+    def __hash__(self):
+        return hash(self.id)


### PR DESCRIPTION
### Closes #47 
- The cards now show up in a QTreeWidget
- I implemented a cache for the filter results, which invalidates after card edits

**Note:** Currently there's a strange issue where if a user does the following, the program hangs for a while before continuing:
1. Filter by a tag (e.g. "N5")
2. Edit a card
3. Filter by "-- All Decks --"
4. Filter by the same tag as before ("N5")
5. Filter again by "--All Decks --"

The program will hang for a while before continuing as expected. I'm not sure why this is, so it would be worth looking into