### PR TITLE
Add delete to browser

### DIFF
--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -263,12 +263,19 @@ class CardBrowserWidget(QWidget):
                 if selected_card in deck.cards:
                     deck.cards.remove(selected_card)
                     deck.is_modified = True
-                    break
-            self.all_cards.remove(selected_card)
 
-            self.update_filter_cache(set(selected_card.tags))
+                    # Cards seemingly have to be removed from the all_cards list as well as the current_card_list
+                    self.all_cards.remove(selected_card)
+                    if selected_card in self.current_card_list:
+
+                        self.current_card_list.remove(selected_card)
 
             self.update_card_list(self.current_card_list)
+            # Update the filter list just in case the card deleted was the only one with a certain tag
+            self.update_filter_list(self.all_decks)
+            # Update the filter cache and tag-to-card index to remove the card from any tag filters
+            self.update_filter_cache(selected_card.tags)
+            self.build_tag_index()
 
     def delete_tag(self):
         """

--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -200,12 +200,11 @@ class CardBrowserWidget(QWidget):
         Builds a reverse index from tags to cards.
         """
         self.tag_to_cards = {}
-        for deck in self.all_decks:
-            for card in deck.cards:
-                for tag in card.tags:
-                    if tag not in self.tag_to_cards:
-                        self.tag_to_cards[tag] = set()
-                    self.tag_to_cards[tag].add(card)
+        for card in self.all_cards:
+            for tag in card.tags:
+                if tag not in self.tag_to_cards:
+                    self.tag_to_cards[tag] = set()
+                self.tag_to_cards[tag].add(card)
 
     def filter_cards_by_tag(self, tag):
         """

--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -267,7 +267,6 @@ class CardBrowserWidget(QWidget):
                     # Cards seemingly have to be removed from the all_cards list as well as the current_card_list
                     self.all_cards.remove(selected_card)
                     if selected_card in self.current_card_list:
-
                         self.current_card_list.remove(selected_card)
 
             self.update_card_list(self.current_card_list)

--- a/widgets/CardEditWidget.py
+++ b/widgets/CardEditWidget.py
@@ -8,7 +8,7 @@ from models.Flashcard import Flashcard
 
 
 class CardEditSignals(QObject):
-    card_edited = Signal(Flashcard)
+    card_edited = Signal(Flashcard, Flashcard)
 
 
 class CardEditWidget(QWidget):
@@ -52,9 +52,10 @@ class CardEditWidget(QWidget):
 
     @Slot()
     def save_card(self):
+        old_card = Flashcard(question=self.card.question, answer=self.card.answer, tags=self.card.tags)
         self.card.question = self.front_input.plain_text
         self.card.answer = self.back_input.plain_text
         self.card.tags = self.tags_input.text.split()
 
-        self.signals.card_edited.emit(self.card)
+        self.signals.card_edited.emit(self.card, old_card)
         self.close()


### PR DESCRIPTION
### Feature update: Delete Tags in the Browser
- Users can now select a tag after clicking on one in the filter list
- Users can now remove add and remove tags from cards in the card editor
- Updated the Browser to using a list of cards for keeping track of what to show in the card list, rather than starting with decks every time 
- Fixed a bug where cards weren't being deleted properly from the total list of cards 