### PR TITLE
Add fonts

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,6 +33,9 @@ class MainWindow(QWidget):
             self.layout.add_widget(self.no_decks_label)
         self.deck_list_widget = DeckListWidget(self.decks)
         self.layout.add_widget(self.deck_list_widget)
+        if not self.decks:
+            self.no_decks_label.show()
+            self.deck_list_widget.hide()
 
         # After clicking a "Add card" button, the AddCardWidget will be displayed
         self.button_layout = QHBoxLayout()

--- a/main.py
+++ b/main.py
@@ -27,6 +27,8 @@ class MainWindow(QWidget):
         self.layout = QVBoxLayout()
         self.decks = app_decks
         self.no_decks_label = QLabel('No decks found. Click "Add Deck" to create a new deck, or "Generate Default Decks" to generate decks for JLPT N5-N1.')
+        self.no_decks_label.font = default_text_font
+        self.no_decks_label.alignment = Qt.AlignCenter
         if not self.decks:
             self.layout.add_widget(self.no_decks_label)
         self.deck_list_widget = DeckListWidget(self.decks)

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from widgets.CardBrowserWidget import CardBrowserWidget
 from widgets.DeckListWidget import DeckListWidget
 from widgets.AddCardWidget import AddCardWidget
 from widgets.AddDeckWidget import AddDeckWidget
-from palettes import blue_dark_palette
+from palettes import blue_dark_palette, default_text_font
 
 my_app = QApplication([])
 my_app.set_palette(blue_dark_palette)

--- a/main.py
+++ b/main.py
@@ -11,12 +11,14 @@ from widgets.CardBrowserWidget import CardBrowserWidget
 from widgets.DeckListWidget import DeckListWidget
 from widgets.AddCardWidget import AddCardWidget
 from widgets.AddDeckWidget import AddDeckWidget
-from palettes import blue_dark_palette, default_text_font
+from palettes import blue_dark_palette, default_text_font, button_font
 
 my_app = QApplication([])
 my_app.set_palette(blue_dark_palette)
 
 app_decks = utils.load_decks_from_csv("decks")
+# Set button font for my_app
+my_app.set_font(button_font, "QPushButton")
 
 
 class MainWindow(QWidget):

--- a/palettes.py
+++ b/palettes.py
@@ -5,6 +5,7 @@ from __feature__ import snake_case, true_property
 
 large_label_font = QFont("Times New Roman", 18)
 default_text_font = QFont("Times New Roman", 12)
+card_text_font = QFont("Times New Roman", 18)
 list_item_font = QFont("Times New Roman", 14)
 button_font = QFont("Times New Roman", 12)
 

--- a/palettes.py
+++ b/palettes.py
@@ -5,6 +5,7 @@ from __feature__ import snake_case, true_property
 
 large_label_font = QFont("Times New Roman", 18)
 default_text_font = QFont("Times New Roman", 12)
+list_item_font = QFont("Times New Roman", 14)
 
 palette = {
     'primary_100': QColor('#76c4e8'),

--- a/palettes.py
+++ b/palettes.py
@@ -22,7 +22,9 @@ palette = {
     'dark_500': QColor('#717171'),
     'dark_600': QColor('#8b8b8b'),
     'text': QColor('#e8eaf6'),
-    'highlight': QColor('#0a74a6')
+    'highlight': QColor('#0a74a6'),
+    'pass': QColor('#23ebcd'),
+    'fail': QColor('#ff599c'),
 }
 
 role_to_color_map = {
@@ -33,7 +35,7 @@ role_to_color_map = {
     QPalette.ColorRole.ToolTipBase: palette['dark_300'],
     QPalette.ColorRole.ToolTipText: palette['text'],
     QPalette.ColorRole.Text: palette['text'],
-    QPalette.ColorRole.Button: palette['dark_300'],
+    QPalette.ColorRole.Button: palette['dark_200'],
     QPalette.ColorRole.ButtonText: palette['primary_500'],
     QPalette.ColorRole.BrightText: palette['primary_500'],
     QPalette.ColorRole.Highlight: palette['highlight'],

--- a/palettes.py
+++ b/palettes.py
@@ -6,7 +6,9 @@ from __feature__ import snake_case, true_property
 large_label_font = QFont("Times New Roman", 18)
 default_text_font = QFont("Times New Roman", 12)
 card_text_font = QFont("Times New Roman", 18)
-list_item_font = QFont("Times New Roman", 14)
+deck_list_item_font = QFont("Times New Roman", 14)
+card_list_item_font = QFont("Times New Roman", 14)
+filter_list_item_font = QFont("Times New Roman", 12)
 button_font = QFont("Times New Roman", 12)
 
 palette = {

--- a/palettes.py
+++ b/palettes.py
@@ -6,6 +6,7 @@ from __feature__ import snake_case, true_property
 large_label_font = QFont("Times New Roman", 18)
 default_text_font = QFont("Times New Roman", 12)
 list_item_font = QFont("Times New Roman", 14)
+button_font = QFont("Times New Roman", 12)
 
 palette = {
     'primary_100': QColor('#76c4e8'),

--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -57,6 +57,9 @@ class CardBrowserWidget(QWidget):
         self.card_tree_widget = QTreeWidget()
         self.card_tree_widget.font = card_list_item_font
         self.card_tree_widget.set_header_labels(["Front", "Back", "Tags"])
+        # Give more space for the "Back" column, so it's easier to see the answer
+        self.card_tree_widget.set_column_width(0, 120)
+        self.card_tree_widget.set_column_width(1, 200)
         self.card_tree_widget.clicked.connect(self.on_card_list_clicked)
         self.update_card_list(self.current_card_list)
         self.card_tree_widget.itemDoubleClicked.connect(lambda item: self.show_card_editor(item))
@@ -74,6 +77,7 @@ class CardBrowserWidget(QWidget):
         # Handle closeEvents
         self.install_event_filter(self)
 
+        self.resize(840, 400)
         self.show()
 
     def generate_tag_list(self, app_decks: list[Deck]) -> list[str]:

--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -10,6 +10,7 @@ import utils
 from models.Deck import Deck
 from models.Flashcard import Flashcard
 from widgets.CardEditWidget import CardEditWidget
+from palettes import list_item_font
 
 
 class CardBrowserSignals(QObject):
@@ -46,6 +47,7 @@ class CardBrowserWidget(QWidget):
 
         # Note: when filtering, you should update the current_deck_list to some subset of app_decks, so they stay in sync
         self.filter_list_widget = QListWidget()
+        self.filter_list_widget.font = list_item_font
         self.filter_list_widget.clicked.connect(self.on_filter_list_clicked)
         self.update_filter_list(app_decks)
         self.filter_list_widget.itemDoubleClicked.connect(lambda item: self.select_filter(item))
@@ -53,6 +55,7 @@ class CardBrowserWidget(QWidget):
         self.layout.add_widget(self.filter_list_widget)
 
         self.card_tree_widget = QTreeWidget()
+        self.card_tree_widget.font = list_item_font
         self.card_tree_widget.set_header_labels(["Front", "Back", "Tags"])
         self.card_tree_widget.clicked.connect(self.on_card_list_clicked)
         self.update_card_list(self.current_card_list)

--- a/widgets/CardBrowserWidget.py
+++ b/widgets/CardBrowserWidget.py
@@ -10,7 +10,7 @@ import utils
 from models.Deck import Deck
 from models.Flashcard import Flashcard
 from widgets.CardEditWidget import CardEditWidget
-from palettes import list_item_font
+from palettes import filter_list_item_font, card_list_item_font
 
 
 class CardBrowserSignals(QObject):
@@ -47,7 +47,7 @@ class CardBrowserWidget(QWidget):
 
         # Note: when filtering, you should update the current_deck_list to some subset of app_decks, so they stay in sync
         self.filter_list_widget = QListWidget()
-        self.filter_list_widget.font = list_item_font
+        self.filter_list_widget.font = filter_list_item_font
         self.filter_list_widget.clicked.connect(self.on_filter_list_clicked)
         self.update_filter_list(app_decks)
         self.filter_list_widget.itemDoubleClicked.connect(lambda item: self.select_filter(item))
@@ -55,7 +55,7 @@ class CardBrowserWidget(QWidget):
         self.layout.add_widget(self.filter_list_widget)
 
         self.card_tree_widget = QTreeWidget()
-        self.card_tree_widget.font = list_item_font
+        self.card_tree_widget.font = card_list_item_font
         self.card_tree_widget.set_header_labels(["Front", "Back", "Tags"])
         self.card_tree_widget.clicked.connect(self.on_card_list_clicked)
         self.update_card_list(self.current_card_list)

--- a/widgets/CardEditWidget.py
+++ b/widgets/CardEditWidget.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import Qt, Slot, Signal, QObject
 from __feature__ import snake_case, true_property
 
 from models.Flashcard import Flashcard
+from palettes import default_text_font
 
 
 class CardEditSignals(QObject):
@@ -20,18 +21,24 @@ class CardEditWidget(QWidget):
         self.card = card
 
         self.front_label = QLabel("Front:")
+        self.front_label.font = default_text_font
         self.layout.add_widget(self.front_label)
         self.front_input = QTextEdit()
+        self.front_input.font = default_text_font
         self.layout.add_widget(self.front_input)
 
         self.back_label = QLabel("Back:")
+        self.back_label.font = default_text_font
         self.layout.add_widget(self.back_label)
         self.back_input = QTextEdit()
+        self.back_input.font = default_text_font
         self.layout.add_widget(self.back_input)
 
         self.tags_label = QLabel("Tags (seperate by spaces):")
+        self.tags_label.font = default_text_font
         self.layout.add_widget(self.tags_label)
         self.tags_input = QLineEdit()
+        self.tags_input.font = default_text_font
         self.layout.add_widget(self.tags_input)
 
         self.save_button = QPushButton("Save")

--- a/widgets/CardWidget.py
+++ b/widgets/CardWidget.py
@@ -9,7 +9,7 @@ from __feature__ import snake_case, true_property
 
 from models.Deck import Deck
 import utils
-from palettes import palette
+from palettes import palette, card_text_font
 
 
 class CardWidget(QWidget):
@@ -38,10 +38,12 @@ class CardWidget(QWidget):
 
         # Question and Answer Labels
         self.question_label = QLabel("")
+        self.question_label.font = card_text_font
         self.question_label.alignment = Qt.AlignCenter
         vbox.add_widget(self.question_label)
 
         self.answer_label = QLabel()
+        self.answer_label.font = card_text_font
         self.answer_label.alignment = Qt.AlignCenter
         vbox.add_widget(self.answer_label)
 

--- a/widgets/CardWidget.py
+++ b/widgets/CardWidget.py
@@ -9,6 +9,7 @@ from __feature__ import snake_case, true_property
 
 from models.Deck import Deck
 import utils
+from palettes import palette
 
 
 class CardWidget(QWidget):
@@ -32,7 +33,8 @@ class CardWidget(QWidget):
         self.update_card_list()
 
         vbox = QVBoxLayout()
-        btn_style = "background-color: #5a6363; color: #fff;"
+        pass_btn_style = f"background-color: { palette['dark_300'].name()}; color: {palette['pass'].name()};"
+        fail_btn_style = f"background-color: {palette['dark_300'].name()}; color: {palette['fail'].name()};"
 
         # Question and Answer Labels
         self.question_label = QLabel("")
@@ -48,18 +50,18 @@ class CardWidget(QWidget):
 
         self.show_answer_btn = QPushButton("Show Answer")
         self.show_answer_btn.clicked.connect(self.on_show_answer_click)
-        self.show_answer_btn.style_sheet = btn_style
+        # self.show_answer_btn.style_sheet = btn_style
         button_box.add_widget(self.show_answer_btn)
 
         self.fail_btn = QPushButton("Fail")
         self.fail_btn.clicked.connect(lambda: self.on_review_click(0))
-        self.fail_btn.style_sheet = btn_style
+        self.fail_btn.style_sheet = fail_btn_style
         self.fail_btn.hide()
         button_box.add_widget(self.fail_btn)
 
         self.pass_btn = QPushButton("Pass")
         self.pass_btn.clicked.connect(lambda: self.on_review_click(3))
-        self.pass_btn.style_sheet = btn_style
+        self.pass_btn.style_sheet = pass_btn_style
         self.pass_btn.hide()
         button_box.add_widget(self.pass_btn)
 

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -10,7 +10,7 @@ from __feature__ import snake_case, true_property
 import utils
 from models.Deck import Deck
 from widgets.CardWidget import CardWidget
-from palettes import list_item_font
+from palettes import deck_list_item_font
 
 
 class DeckListWidget(QWidget):
@@ -29,7 +29,7 @@ class DeckListWidget(QWidget):
         self.decks = decks
         self.layout = QVBoxLayout()
         self.deck_list_widget = QWidget()
-        self.deck_list_widget.font = list_item_font
+        self.deck_list_widget.font = deck_list_item_font
         self.deck_list = QVBoxLayout(self.deck_list_widget)
         # Create a stacked widget to switch between the deck list and the card view
         self.stacked_widget = QStackedWidget()

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -10,6 +10,7 @@ from __feature__ import snake_case, true_property
 import utils
 from models.Deck import Deck
 from widgets.CardWidget import CardWidget
+from palettes import list_item_font
 
 
 class DeckListWidget(QWidget):
@@ -28,6 +29,7 @@ class DeckListWidget(QWidget):
         self.decks = decks
         self.layout = QVBoxLayout()
         self.deck_list_widget = QWidget()
+        self.deck_list_widget.font = list_item_font
         self.deck_list = QVBoxLayout(self.deck_list_widget)
         # Create a stacked widget to switch between the deck list and the card view
         self.stacked_widget = QStackedWidget()


### PR DESCRIPTION
- Moved styling to the palettes.py file, and added general fonts categories for window text, list items, and button text. 
- When reviewing, the "pass"/"fail" buttons have green/red text
- The text showing that there are no decks is now centered on the screen
- The column widths for the card browser's card list have been widened
- The card browser has a new default opening size