### PR TITLE
Add toast widget

### DIFF
--- a/main.py
+++ b/main.py
@@ -158,6 +158,7 @@ class MainWindow(QWidget):
 
         self.decks = utils.load_decks_from_csv("decks")
         self.reset_deck_list()
+        self.toast.show_toast("Decks generated!")
         dialog.delete_later()
 
 

--- a/main.py
+++ b/main.py
@@ -28,7 +28,8 @@ class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
         self.layout = QVBoxLayout()
-        self.toast = Toast()
+        self.toast = Toast(self)
+        self.toast.hide()
         self.decks = app_decks
         self.no_decks_label = QLabel(
             'No decks found. Click "Add Deck" to create a new deck, or "Generate Default Decks" to generate decks for JLPT N5-N1.')

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from widgets.CardBrowserWidget import CardBrowserWidget
 from widgets.DeckListWidget import DeckListWidget
 from widgets.AddCardWidget import AddCardWidget
 from widgets.AddDeckWidget import AddDeckWidget
+from widgets.Toast import Toast
 from theme import blue_dark_palette, default_text_font, button_font
 
 my_app = QApplication([])
@@ -27,6 +28,7 @@ class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
         self.layout = QVBoxLayout()
+        self.toast = Toast()
         self.decks = app_decks
         self.no_decks_label = QLabel(
             'No decks found. Click "Add Deck" to create a new deck, or "Generate Default Decks" to generate decks for JLPT N5-N1.')
@@ -95,6 +97,7 @@ class MainWindow(QWidget):
         """ This method displays the AddDeckWidget when the "Add Deck" button is clicked. """
         add_deck_widget = AddDeckWidget(self.deck_list_widget)
         add_deck_widget.signals.deck_added.connect(self.reset_deck_list)
+        add_deck_widget.signals.deck_added.connect(lambda: self.toast.show_toast("Deck added!"))
 
     @Slot()
     def show_card_browser_widget(self):

--- a/main.py
+++ b/main.py
@@ -16,10 +16,9 @@ from theme import blue_dark_palette, default_text_font, button_font
 
 my_app = QApplication([])
 my_app.set_palette(blue_dark_palette)
+my_app.set_font(button_font, "QPushButton")
 
 app_decks = utils.load_decks_from_csv("decks")
-# Set button font for my_app
-my_app.set_font(button_font, "QPushButton")
 
 
 class MainWindow(QWidget):
@@ -92,6 +91,7 @@ class MainWindow(QWidget):
     def show_add_card_widget(self):
         """This method displays the AddCardWidget when the "Add Card" button is clicked."""
         add_card_widget = AddCardWidget(self.decks)
+        add_card_widget.signals.card_added.connect(lambda: self.toast.show_toast("Card added!"))
 
     @Slot()
     def show_add_deck_widget(self):

--- a/widgets/AddCardWidget.py
+++ b/widgets/AddCardWidget.py
@@ -87,7 +87,7 @@ class AddCardWidget(QWidget):
             shortcut_exit.activated.connect(error_msg.close)
             error_msg.exec_()
             return
-        answer = self.answer_input.text
+        answer = self.answer_input.plain_text
         tags = self.tags_input.text.split(' ')
 
         for deck in self.decks:

--- a/widgets/AddCardWidget.py
+++ b/widgets/AddCardWidget.py
@@ -1,6 +1,6 @@
 from PySide6.QtGui import QShortcut, QKeySequence
 from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QLineEdit, QComboBox, QMessageBox, QTextEdit
-from PySide6.QtCore import Slot
+from PySide6.QtCore import Slot, QObject, Signal
 
 # noinspection PyUnresolvedReference
 from __feature__ import snake_case, true_property
@@ -10,8 +10,14 @@ from models.Flashcard import Flashcard
 from theme import default_text_font
 
 
+class AddCardWidgetSignals(QObject):
+    card_added = Signal()
+
+
 class AddCardWidget(QWidget):
     """This class defines the widget that will be displayed when the user clicks the "Add Card" button."""
+
+    signals = AddCardWidgetSignals()
 
     def __init__(self, app_decks):
         """
@@ -88,4 +94,6 @@ class AddCardWidget(QWidget):
             if deck.name == deck_name:
                 deck.append_card(Flashcard(question, answer, tags=tags))
                 break
+
+        self.signals.card_added.emit()
         self.close()

--- a/widgets/Toast.py
+++ b/widgets/Toast.py
@@ -1,0 +1,22 @@
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout
+from PySide6.QtCore import Qt, Slot, QTimer
+
+# noinspection PyUnresolvedReference
+from __feature__ import snake_case, true_property
+
+
+class Toast(QLabel):
+    def __init__(self):
+        super().__init__()
+        self.window_flag = Qt.FramelessWindowHint
+
+        self.alignment = Qt.AlignCenter
+        self.timer = QTimer(parent=self)
+        self.timer.single_shot = True
+        self.timer.timeout.connect(self.hide)
+
+    def show_toast(self, message: str, duration: int = 2000):
+        self.text = message
+        self.show()
+        self.timer.start(duration)
+

--- a/widgets/Toast.py
+++ b/widgets/Toast.py
@@ -4,11 +4,13 @@ from PySide6.QtCore import Qt, Slot, QTimer
 # noinspection PyUnresolvedReference
 from __feature__ import snake_case, true_property
 
+from theme import default_text_font, palette
 
 class Toast(QLabel):
-    def __init__(self):
-        super().__init__()
-        self.window_flag = Qt.FramelessWindowHint
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.window_flag = Qt.ToolTip
+        self.font = default_text_font
 
         self.alignment = Qt.AlignCenter
         self.timer = QTimer(parent=self)
@@ -17,6 +19,10 @@ class Toast(QLabel):
 
     def show_toast(self, message: str, duration: int = 2000):
         self.text = message
+        self.adjust_size()
+        margin_bottom = 50
+        margin_right = 50
+        self.move(self.parent().width - self.width - margin_right, self.parent().height - self.height - margin_bottom)
         self.show()
         self.timer.start(duration)
 

--- a/widgets/Toast.py
+++ b/widgets/Toast.py
@@ -11,6 +11,7 @@ class Toast(QLabel):
         super().__init__(parent)
         self.window_flag = Qt.ToolTip
         self.font = default_text_font
+        self.style_sheet = f"background-color: {palette['dark_200'].name()}; color: {palette['text'].name()}; border-radius: 5px; padding: 3px;"
 
         self.alignment = Qt.AlignCenter
         self.timer = QTimer(parent=self)

--- a/widgets/Toast.py
+++ b/widgets/Toast.py
@@ -1,10 +1,11 @@
-from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout
-from PySide6.QtCore import Qt, Slot, QTimer
+from PySide6.QtWidgets import QLabel
+from PySide6.QtCore import Qt, QTimer
 
 # noinspection PyUnresolvedReference
 from __feature__ import snake_case, true_property
 
 from theme import default_text_font, palette
+
 
 class Toast(QLabel):
     def __init__(self, parent=None):
@@ -26,4 +27,3 @@ class Toast(QLabel):
         self.move(self.parent().width - self.width - margin_right, self.parent().height - self.height - margin_bottom)
         self.show()
         self.timer.start(duration)
-


### PR DESCRIPTION
### Closes #64 
- There is now a custom toast widget that can be shown with a specified message for a specified duration
- When users add decks, card, or if they generate decks, the toast shows in the bottom right for a couple of seconds