### PR TITLE
Add settings widget

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ my_app.set_palette(blue_dark_palette)
 my_app.set_font(button_font, "QPushButton")
 
 app_decks = utils.load_decks_from_csv("decks")
+settings = utils.load_config("settings.ini")
 
 
 class MainWindow(QWidget):

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from widgets.DeckListWidget import DeckListWidget
 from widgets.AddCardWidget import AddCardWidget
 from widgets.AddDeckWidget import AddDeckWidget
 from widgets.Toast import Toast
+from widgets.SettingsDialog import SettingsDialog
 from theme import blue_dark_palette, default_text_font, button_font
 
 my_app = QApplication([])
@@ -65,6 +66,11 @@ class MainWindow(QWidget):
         self.save_button.clicked.connect(lambda: utils.save_decks_to_csv(app_decks, "decks"))
         self.button_layout.add_widget(self.save_button)
 
+        self.settings_button = QPushButton("Settings")
+        self.settings_button.tool_tip = "Shortcut: Alt+S"
+        self.settings_button.clicked.connect(self.show_settings_dialog)
+        self.button_layout.add_widget(self.settings_button)
+
         self.generate_default_decks_button = QPushButton("Generate Default Decks")
         self.generate_default_decks_button.clicked.connect(self.show_generation_dialog)
         self.generate_default_decks_button.tool_tip = "Generate default decks for JLPT N5-N1"
@@ -77,7 +83,8 @@ class MainWindow(QWidget):
             "Ctrl+N": self.show_add_card_widget,
             "Ctrl+D": self.show_add_deck_widget,
             "Ctrl+B": self.show_card_browser_widget,
-            "Ctrl+Q": self.close
+            "Ctrl+Q": self.close,
+            "Alt+S": self.show_settings_dialog
         })
 
         self.set_layout(self.layout)
@@ -163,6 +170,13 @@ class MainWindow(QWidget):
         self.reset_deck_list()
         self.toast.show_toast("Decks generated!")
         dialog.delete_later()
+
+    @Slot()
+    def show_settings_dialog(self):
+        """ This method displays the settings widget. """
+        settings_dialog = SettingsDialog(settings)
+        settings_dialog.exec()
+
 
 
 main_window = MainWindow()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 import re
 import csv
+import configparser
 from uuid import uuid4
 
 import requests
@@ -167,3 +168,9 @@ def setup_shortcuts(widget: QWidget, shortcuts: dict) -> None:
     for key_sequence, action in shortcuts.items():
         shortcut = QShortcut(QKeySequence(key_sequence), widget)
         shortcut.activated.connect(action)
+
+
+def load_config(filename: str):
+    config = configparser.ConfigParser()
+    config.read(filename)
+    return config

--- a/utils.py
+++ b/utils.py
@@ -171,6 +171,11 @@ def setup_shortcuts(widget: QWidget, shortcuts: dict) -> None:
 
 
 def load_config(filename: str) -> configparser.ConfigParser:
+    """
+    Load a configuration file
+    :param filename: The filename of the configuration file
+    :return: A ConfigParser instance with the configuration loaded
+    """
     config = configparser.ConfigParser()
     config.read(filename)
     return config

--- a/utils.py
+++ b/utils.py
@@ -186,12 +186,14 @@ def load_config(filename: str) -> configparser.ConfigParser:
     :param filename: The filename of the configuration file
     :return: A ConfigParser instance with the configuration loaded
     """
+    os.path.exists(filename) or save_config(default_config, filename)
     config = configparser.ConfigParser()
     config.read(filename)
     # If the configuration file is empty, load the default configuration
     if not config.sections():
         config.read_dict(default_config)
         save_config(config, filename)
+
     return config
 
 

--- a/utils.py
+++ b/utils.py
@@ -179,3 +179,8 @@ def load_config(filename: str) -> configparser.ConfigParser:
     config = configparser.ConfigParser()
     config.read(filename)
     return config
+
+
+def save_config(config: configparser.ConfigParser, filename: str):
+    with open(filename, 'w') as file:
+        config.write(file)

--- a/utils.py
+++ b/utils.py
@@ -181,6 +181,12 @@ def load_config(filename: str) -> configparser.ConfigParser:
     return config
 
 
-def save_config(config: configparser.ConfigParser, filename: str):
+def save_config(config: configparser.ConfigParser, filename: str) -> None:
+    """
+    Save a configuration file
+    :param config: The ConfigParser instance to save
+    :param filename: The filename to save the configuration to
+    :return: None
+    """
     with open(filename, 'w') as file:
         config.write(file)

--- a/utils.py
+++ b/utils.py
@@ -170,7 +170,7 @@ def setup_shortcuts(widget: QWidget, shortcuts: dict) -> None:
         shortcut.activated.connect(action)
 
 
-def load_config(filename: str):
+def load_config(filename: str) -> configparser.ConfigParser:
     config = configparser.ConfigParser()
     config.read(filename)
     return config

--- a/utils.py
+++ b/utils.py
@@ -170,6 +170,16 @@ def setup_shortcuts(widget: QWidget, shortcuts: dict) -> None:
         shortcut.activated.connect(action)
 
 
+# CONFIGURATION
+default_config = configparser.ConfigParser()
+default_config['DEFAULT'] = {
+    'decks_directory': 'decks',
+    'daily_reviews_limit': 100,
+    'new_card_limit': 20,
+    'theme': 'blue_dark'
+}
+
+
 def load_config(filename: str) -> configparser.ConfigParser:
     """
     Load a configuration file
@@ -178,6 +188,10 @@ def load_config(filename: str) -> configparser.ConfigParser:
     """
     config = configparser.ConfigParser()
     config.read(filename)
+    # If the configuration file is empty, load the default configuration
+    if not config.sections():
+        config.read_dict(default_config)
+        save_config(config, filename)
     return config
 
 

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -10,7 +10,6 @@ from __feature__ import snake_case, true_property
 from theme import default_text_font
 
 
-
 class SettingsDialog(QDialog):
     def __init__(self, settings: ConfigParser):
         super().__init__()
@@ -27,7 +26,7 @@ class SettingsDialog(QDialog):
         self.review_limit_input.font = default_text_font
         only_int_validator = QIntValidator()
         only_int_validator.set_range(0, 1000)
-        self.review_limit_input.validator = only_int_validator
+        self.review_limit_input.set_validator(only_int_validator)
         review_layout.add_widget(self.review_limit_input)
         self.layout.add_layout(review_layout)
 
@@ -37,7 +36,7 @@ class SettingsDialog(QDialog):
         new_cards_layout.add_widget(self.new_cards_limit_label)
         self.new_cards_limit_input = QLineEdit()
         self.new_cards_limit_input.font = default_text_font
-        self.new_cards_limit_input.validator = only_int_validator
+        self.new_cards_limit_input.set_validator(only_int_validator)
         new_cards_layout.add_widget(self.new_cards_limit_input)
         self.layout.add_layout(new_cards_layout)
 

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -1,7 +1,8 @@
 from configparser import ConfigParser
 
 from PySide6.QtGui import QIntValidator
-from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QDialog
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QDialog, QFileDialog, \
+    QComboBox
 from PySide6.QtCore import Qt, Slot
 
 # noinspection PyUnresolvedReference
@@ -18,6 +19,21 @@ class SettingsDialog(QDialog):
         self.settings = settings
         self.layout = QVBoxLayout()
         self.layout.alignment = Qt.AlignCenter
+
+        directory_layout = QHBoxLayout()
+        self.directory_label = QLabel("Decks Directory:")
+        self.directory_label.font = default_text_font
+        directory_layout.add_widget(self.directory_label)
+        self.directory_input = QLineEdit()
+        self.directory_input.font = default_text_font
+        self.directory_input.text = self.settings['USER']['decks_directory'] if 'USER' in self.settings.sections() else 'decks'
+        directory_layout.add_widget(self.directory_input)
+
+        self.select_directory_button = QPushButton("Select Directory")
+        self.select_directory_button.clicked.connect(self.get_directory)
+        directory_layout.add_widget(self.select_directory_button)
+        self.layout.add_layout(directory_layout)
+
 
         review_layout = QHBoxLayout()
         self.review_limit_label = QLabel("Review Limit:")
@@ -55,7 +71,16 @@ class SettingsDialog(QDialog):
         # If the user section doesn't exist, it will be a copy of the default settings
         if 'USER' not in self.settings.sections():
             self.settings['USER'] = self.settings['DEFAULT']
+        self.settings['USER']['decks_directory'] = self.directory_input.text
         self.settings['USER']['daily_reviews_limit'] = self.review_limit_input.text
         self.settings['USER']['new_card_limit'] = self.new_cards_limit_input.text
         utils.save_config(self.settings, "settings.ini")
         self.close()
+
+    @Slot()
+    def get_directory(self):
+        dialog = QFileDialog()
+        dialog.file_mode = QFileDialog.Directory
+        dialog.option = QFileDialog.ShowDirsOnly
+        directory = dialog.get_existing_directory()
+        self.directory_input.text = directory

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -24,6 +24,7 @@ class SettingsDialog(QDialog):
         review_layout.add_widget(self.review_limit_label)
         self.review_limit_input = QLineEdit()
         self.review_limit_input.font = default_text_font
+        self.review_limit_input.text = self.settings['USER']['daily_reviews_limit'] if 'USER' in self.settings.sections() else '100'
         only_int_validator = QIntValidator()
         only_int_validator.set_range(0, 1000)
         self.review_limit_input.set_validator(only_int_validator)
@@ -37,6 +38,7 @@ class SettingsDialog(QDialog):
         self.new_cards_limit_input = QLineEdit()
         self.new_cards_limit_input.font = default_text_font
         self.new_cards_limit_input.set_validator(only_int_validator)
+        self.new_cards_limit_input.text = self.settings['USER']['new_card_limit'] if 'USER' in self.settings.sections() else '20'
         new_cards_layout.add_widget(self.new_cards_limit_input)
         self.layout.add_layout(new_cards_layout)
 

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -7,6 +7,7 @@ from PySide6.QtCore import Qt, Slot
 # noinspection PyUnresolvedReference
 from __feature__ import snake_case, true_property
 
+import utils
 from theme import default_text_font
 
 
@@ -43,7 +44,18 @@ class SettingsDialog(QDialog):
         self.layout.add_layout(new_cards_layout)
 
         self.save_button = QPushButton("Save")
+        self.save_button.clicked.connect(self.save_settings)
         self.layout.add_widget(self.save_button)
 
         self.resize(300, 200)
         self.set_layout(self.layout)
+
+    @Slot()
+    def save_settings(self):
+        # If the user section doesn't exist, it will be a copy of the default settings
+        if 'USER' not in self.settings.sections():
+            self.settings['USER'] = self.settings['DEFAULT']
+        self.settings['USER']['daily_reviews_limit'] = self.review_limit_input.text
+        self.settings['USER']['new_card_limit'] = self.new_cards_limit_input.text
+        utils.save_config(self.settings, "settings.ini")
+        self.close()

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -1,0 +1,48 @@
+from configparser import ConfigParser
+
+from PySide6.QtGui import QIntValidator
+from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout, QLineEdit, QDialog
+from PySide6.QtCore import Qt, Slot
+
+# noinspection PyUnresolvedReference
+from __feature__ import snake_case, true_property
+
+from theme import default_text_font
+
+
+
+class SettingsDialog(QDialog):
+    def __init__(self, settings: ConfigParser):
+        super().__init__()
+        self.window_title = "Settings"
+        self.settings = settings
+        self.layout = QVBoxLayout()
+        self.layout.alignment = Qt.AlignCenter
+
+        review_layout = QHBoxLayout()
+        self.review_limit_label = QLabel("Review Limit:")
+        self.review_limit_label.font = default_text_font
+        review_layout.add_widget(self.review_limit_label)
+        self.review_limit_input = QLineEdit()
+        self.review_limit_input.font = default_text_font
+        only_int_validator = QIntValidator()
+        only_int_validator.set_range(0, 1000)
+        self.review_limit_input.validator = only_int_validator
+        review_layout.add_widget(self.review_limit_input)
+        self.layout.add_layout(review_layout)
+
+        new_cards_layout = QHBoxLayout()
+        self.new_cards_limit_label = QLabel("New Cards Limit:")
+        self.new_cards_limit_label.font = default_text_font
+        new_cards_layout.add_widget(self.new_cards_limit_label)
+        self.new_cards_limit_input = QLineEdit()
+        self.new_cards_limit_input.font = default_text_font
+        self.new_cards_limit_input.validator = only_int_validator
+        new_cards_layout.add_widget(self.new_cards_limit_input)
+        self.layout.add_layout(new_cards_layout)
+
+        self.save_button = QPushButton("Save")
+        self.layout.add_widget(self.save_button)
+
+        self.resize(300, 200)
+        self.set_layout(self.layout)

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -34,6 +34,15 @@ class SettingsDialog(QDialog):
         directory_layout.add_widget(self.select_directory_button)
         self.layout.add_layout(directory_layout)
 
+        themes_layout = QHBoxLayout()
+        self.themes_label = QLabel("Themes:")
+        self.themes_label.font = default_text_font
+        themes_layout.add_widget(self.themes_label)
+        self.themes_input = QComboBox(self)
+        self.themes_input.font = default_text_font
+        self.themes_input.add_items(["Blue Dark"])
+        themes_layout.add_widget(self.themes_input)
+        self.layout.add_layout(themes_layout)
 
         review_layout = QHBoxLayout()
         self.review_limit_label = QLabel("Review Limit:")
@@ -74,6 +83,7 @@ class SettingsDialog(QDialog):
         self.settings['USER']['decks_directory'] = self.directory_input.text
         self.settings['USER']['daily_reviews_limit'] = self.review_limit_input.text
         self.settings['USER']['new_card_limit'] = self.new_cards_limit_input.text
+        self.settings['USER']['theme'] = self.themes_input.current_text.lower().replace(' ', '_')
         utils.save_config(self.settings, "settings.ini")
         self.close()
 

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -72,7 +72,7 @@ class SettingsDialog(QDialog):
         self.save_button.clicked.connect(self.save_settings)
         self.layout.add_widget(self.save_button)
 
-        self.resize(300, 200)
+        self.resize(700, 250)
         self.set_layout(self.layout)
 
     @Slot()


### PR DESCRIPTION
### Closes #24 and introduces #68
- A settings dialog is now accessible through a shortcut and a button on the home screen
- Note that the settings currently aren't enforced by the program, but users can do the following: 
  - Change what directory decks are stored in
  - Change which theme they're using
  - Limit the number of review cards to review in a day
  - Limit the number of new cards to learn in a day