### PR TITLE
Add toolbar

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,9 @@ class MainWindow(QWidget):
         # Each menu is a dictionary of actions, where the key is the action name and the value is a tuple of the action and its shortcut
         menu_map = {
             "File": {
-                "Save": (lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")), "Ctrl+S"),
+                "Save": (
+                lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")),
+                "Ctrl+S"),
                 "Exit": (self.close, "Ctrl+Q"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
             },
@@ -127,7 +129,6 @@ class MainWindow(QWidget):
                 menu.add_action(menu_action)
 
         self.layout.set_menu_bar(menu_bar)
-
 
     @Slot()
     def show_add_card_widget(self):
@@ -211,6 +212,7 @@ class MainWindow(QWidget):
         """ This method displays the settings widget. """
         settings_dialog = SettingsDialog(settings)
         settings_dialog.exec()
+
 
 main_window = MainWindow()
 main_window.show()

--- a/main.py
+++ b/main.py
@@ -81,18 +81,17 @@ class MainWindow(QWidget):
 
         self.layout.add_layout(self.button_layout)
 
-        utils.setup_shortcuts(self, shortcuts={
-            "Ctrl+S": lambda: utils.save_decks_to_csv(app_decks,
-                                                      settings.get("DEFAULT", "decks_directory", fallback="decks")),
-            "Ctrl+N": self.show_add_card_widget,
-            "Ctrl+D": self.show_add_deck_widget,
-            "Ctrl+B": self.show_card_browser_widget,
-            "Ctrl+Q": self.close,
-            "Alt+S": self.show_settings_dialog,
-            "F9": lambda: self.show_normal(),
-            "F10": lambda: self.show_maximized(),
-            "F11": lambda: self.show_full_screen()
-        })
+        # Shortcuts are being overridden by the menu bar, so they are commented out unless a shortcut not present in the menu bar
+        # is needed.
+        # utils.setup_shortcuts(self, shortcuts={
+        #     "Ctrl+S": lambda: utils.save_decks_to_csv(app_decks,
+        #                                               settings.get("DEFAULT", "decks_directory", fallback="decks")),
+        #     "Ctrl+N": self.show_add_card_widget,
+        #     "Ctrl+D": self.show_add_deck_widget,
+        #     "Ctrl+B": self.show_card_browser_widget,
+        #     "Ctrl+Q": self.close,
+        #     "Alt+S": self.show_settings_dialog
+        # })
 
         self.set_layout(self.layout)
 
@@ -112,8 +111,8 @@ class MainWindow(QWidget):
                     lambda: utils.save_decks_to_csv(app_decks,
                                                     settings.get("USER", "decks_directory", fallback="decks")),
                     "Ctrl+S"),
+                "Exit": (self.close, "Ctrl+Q"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
-                "Exit": (self.close, "Ctrl+Q")
             },
             "Edit": {
                 "Add Card": (self.show_add_card_widget, "Ctrl+N"),

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtGui import QFont, QAction
+from PySide6.QtGui import QFont, QAction, QIcon
 from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QDialog, QCheckBox, QLabel, \
     QMenuBar
 # noinspection PyUnresolvedReferences
@@ -102,32 +102,29 @@ class MainWindow(QWidget):
     def setup_menu(self):
         menu_bar = QMenuBar(self)
 
-        file_menu = menu_bar.add_menu("File")
-        save_action = QAction("Save", self)
-        save_action.triggered.connect(
-            lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")))
-        file_menu.add_action(save_action)
+        # Each menu is a dictionary of actions, where the key is the action name and the value is a tuple of the action and its shortcut
+        menu_map = {
+            "File": {
+                "Save": (lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")), "Ctrl+S"),
+                "Exit": (self.close, "Ctrl+Q"),
+                "Settings": (self.show_settings_dialog, "Alt+S"),
+            },
+            "Edit": {
+                "Add Card": (self.show_add_card_widget, "Ctrl+N"),
+                "Add Deck": (self.show_add_deck_widget, "Ctrl+D"),
+                "Browse Cards": (self.show_card_browser_widget, "Ctrl+B")
+            }
+        }
 
-        exit_action = QAction("Exit", self)
-        exit_action.triggered.connect(self.close)
-        file_menu.add_action(exit_action)
-
-        preferences_action = QAction("Preferences", self)
-        preferences_action.triggered.connect(self.show_settings_dialog)
-        file_menu.add_action(preferences_action)
-
-        edit_menu = menu_bar.add_menu("Edit")
-        add_card_action = QAction("Add Card", self)
-        add_card_action.triggered.connect(self.show_add_card_widget)
-        edit_menu.add_action(add_card_action)
-
-        add_deck_action = QAction("Add Deck", self)
-        add_deck_action.triggered.connect(self.show_add_deck_widget)
-        edit_menu.add_action(add_deck_action)
-
-        browse_cards_action = QAction("Browse Cards", self)
-        browse_cards_action.triggered.connect(self.show_card_browser_widget)
-        edit_menu.add_action(browse_cards_action)
+        # Loop through the map and build each menu
+        for menu_name, actions in menu_map.items():
+            menu = menu_bar.add_menu(menu_name)
+            for action_name, (action, shortcut) in actions.items():
+                menu_action = QAction(action_name, self)
+                menu_action.triggered.connect(action)
+                if shortcut:
+                    menu_action.shortcut = shortcut
+                menu.add_action(menu_action)
 
         self.layout.set_menu_bar(menu_bar)
 

--- a/main.py
+++ b/main.py
@@ -1,8 +1,9 @@
 import sys
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtGui import QFont
-from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QDialog, QCheckBox, QLabel
+from PySide6.QtGui import QFont, QAction
+from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QDialog, QCheckBox, QLabel, \
+    QMenuBar
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property
 
@@ -29,6 +30,7 @@ class MainWindow(QWidget):
     def __init__(self):
         super().__init__()
         self.layout = QVBoxLayout()
+        self.setup_menu()
         self.toast = Toast(self)
         self.toast.hide()
         self.decks = app_decks
@@ -96,6 +98,24 @@ class MainWindow(QWidget):
         # self.palette = Qt.black
 
         self.show()
+
+    def setup_menu(self):
+        menu_bar = QMenuBar(self)
+
+        file_menu = menu_bar.add_menu("File")
+        save_action = QAction("Save", self)
+        save_action.triggered.connect(
+            lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")))
+        file_menu.add_action(save_action)
+
+        exit_action = QAction("Exit", self)
+        exit_action.triggered.connect(self.close)
+        file_menu.add_action(exit_action)
+
+
+
+        self.layout.set_menu_bar(menu_bar)
+
 
     @Slot()
     def show_add_card_widget(self):

--- a/main.py
+++ b/main.py
@@ -112,8 +112,8 @@ class MainWindow(QWidget):
                     lambda: utils.save_decks_to_csv(app_decks,
                                                     settings.get("USER", "decks_directory", fallback="decks")),
                     "Ctrl+S"),
-                "Exit": (self.close, "Ctrl+Q"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
+                "Exit": (self.close, "Ctrl+Q")
             },
             "Edit": {
                 "Add Card": (self.show_add_card_widget, "Ctrl+N"),

--- a/main.py
+++ b/main.py
@@ -112,6 +112,10 @@ class MainWindow(QWidget):
         exit_action.triggered.connect(self.close)
         file_menu.add_action(exit_action)
 
+        preferences_action = QAction("Preferences", self)
+        preferences_action.triggered.connect(self.show_settings_dialog)
+        file_menu.add_action(preferences_action)
+
 
 
         self.layout.set_menu_bar(menu_bar)
@@ -199,7 +203,6 @@ class MainWindow(QWidget):
         """ This method displays the settings widget. """
         settings_dialog = SettingsDialog(settings)
         settings_dialog.exec()
-
 
 main_window = MainWindow()
 main_window.show()

--- a/main.py
+++ b/main.py
@@ -88,7 +88,10 @@ class MainWindow(QWidget):
             "Ctrl+D": self.show_add_deck_widget,
             "Ctrl+B": self.show_card_browser_widget,
             "Ctrl+Q": self.close,
-            "Alt+S": self.show_settings_dialog
+            "Alt+S": self.show_settings_dialog,
+            "F9": lambda: self.show_normal(),
+            "F10": lambda: self.show_maximized(),
+            "F11": lambda: self.show_full_screen()
         })
 
         self.set_layout(self.layout)

--- a/main.py
+++ b/main.py
@@ -118,6 +118,11 @@ class MainWindow(QWidget):
                 "Add Card": (self.show_add_card_widget, "Ctrl+N"),
                 "Add Deck": (self.show_add_deck_widget, "Ctrl+D"),
                 "Browse Cards": (self.show_card_browser_widget, "Ctrl+B")
+            },
+            "View": {
+                "Show Normal": (self.show_normal, "F9"),
+                "Show Maximized": (self.show_maximized, "F10"),
+                "Show Full Screen": (self.show_full_screen, "F11")
             }
         }
 

--- a/main.py
+++ b/main.py
@@ -116,7 +116,14 @@ class MainWindow(QWidget):
         preferences_action.triggered.connect(self.show_settings_dialog)
         file_menu.add_action(preferences_action)
 
+        edit_menu = menu_bar.add_menu("Edit")
+        add_card_action = QAction("Add Card", self)
+        add_card_action.triggered.connect(self.show_add_card_widget)
+        edit_menu.add_action(add_card_action)
 
+        add_deck_action = QAction("Add Deck", self)
+        add_deck_action.triggered.connect(self.show_add_deck_widget)
+        edit_menu.add_action(add_deck_action)
 
         self.layout.set_menu_bar(menu_bar)
 

--- a/main.py
+++ b/main.py
@@ -123,6 +123,9 @@ class MainWindow(QWidget):
                 "Show Normal": (self.show_normal, "F9"),
                 "Show Maximized": (self.show_maximized, "F10"),
                 "Show Full Screen": (self.show_full_screen, "F11")
+            },
+            "Tools": {
+                "Generate Default Decks": (self.show_generation_dialog, None)
             }
         }
 

--- a/main.py
+++ b/main.py
@@ -111,8 +111,8 @@ class MainWindow(QWidget):
                     lambda: utils.save_decks_to_csv(app_decks,
                                                     settings.get("USER", "decks_directory", fallback="decks")),
                     "Ctrl+S"),
-                "Exit": (self.close, "Ctrl+Q"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
+                "Exit": (self.close, "Ctrl+Q")
             },
             "Edit": {
                 "Add Card": (self.show_add_card_widget, "Ctrl+N"),

--- a/main.py
+++ b/main.py
@@ -125,6 +125,10 @@ class MainWindow(QWidget):
         add_deck_action.triggered.connect(self.show_add_deck_widget)
         edit_menu.add_action(add_deck_action)
 
+        browse_cards_action = QAction("Browse Cards", self)
+        browse_cards_action.triggered.connect(self.show_card_browser_widget)
+        edit_menu.add_action(browse_cards_action)
+
         self.layout.set_menu_bar(menu_bar)
 
 

--- a/main.py
+++ b/main.py
@@ -109,8 +109,9 @@ class MainWindow(QWidget):
         menu_map = {
             "File": {
                 "Save": (
-                lambda: utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks")),
-                "Ctrl+S"),
+                    lambda: utils.save_decks_to_csv(app_decks,
+                                                    settings.get("USER", "decks_directory", fallback="decks")),
+                    "Ctrl+S"),
                 "Exit": (self.close, "Ctrl+Q"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
             },
@@ -126,6 +127,9 @@ class MainWindow(QWidget):
             },
             "Tools": {
                 "Generate Default Decks": (self.show_generation_dialog, None)
+            },
+            "Help": {
+                "About": (lambda: self.toast.show_toast("JLPyT Flashcards v1.0.0"), None)
             }
         }
 


### PR DESCRIPTION
### A menubar now shows at the top of the window
- There are five sub-menus, each with options available for the user to choose from:
- File
  - Save
  - Settings
  - Exit
- Edit
  - Add Card
  - Add Deck
  - Browse Cards
- View
  - Show Normal
  - Show Maximized
  - Show Full Screen
- Tools
  - Generate Default Decks
- Help
  - About (will show a Toast message with the name of the app and the current version number)

There are shortcuts associated with each option (except the Generating default decks and About options). Soon I'd like to make some slight modifications to the home page, removing some of the buttons to reduce the clutter.