### PR TITLE
Add import from file shortcut

### DIFF
--- a/main.py
+++ b/main.py
@@ -129,6 +129,7 @@ class MainWindow(QWidget):
         # Each menu is a dictionary of actions, where the key is the action name and the value is a tuple of the action and its shortcut
         menu_map = {
             "File": {
+                "Import From File": (self.import_from_file, "Ctrl+I"),
                 "Save": (self.save, "Ctrl+S"),
                 "Settings": (self.show_settings_dialog, "Alt+S"),
                 "Exit": (self.close, "Ctrl+Q")

--- a/main.py
+++ b/main.py
@@ -119,8 +119,10 @@ class MainWindow(QWidget):
         for file_path in file_paths[0]:
             deck = utils.load_deck_from_csv(file_path)
             if deck:
+
                 self.decks.append(deck)
         self.reset_deck_list()
+        self.toast.show_toast("Decks imported!")
 
     def setup_menu(self):
         """ This method sets up the menu bar for the main window, using a dictionary to map menu names to actions. """

--- a/main.py
+++ b/main.py
@@ -107,6 +107,7 @@ class MainWindow(QWidget):
 
 
     def import_from_file(self):
+        """ This method imports decks from a CSV file. """
         file_dialog = QFileDialog()
         file_filter = "CSV File (*.csv)"
         file_dialog.set_directory(settings.get("USER", "decks_directory", fallback="decks"))

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import sys
 from PySide6.QtCore import Qt, Slot
 from PySide6.QtGui import QFont, QAction, QIcon
 from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QDialog, QCheckBox, QLabel, \
-    QMenuBar
+    QMenuBar, QFileDialog
 # noinspection PyUnresolvedReferences
 from __feature__ import snake_case, true_property
 
@@ -104,6 +104,23 @@ class MainWindow(QWidget):
         """ This method saves the decks to CSV files. """
         utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks"))
         self.toast.show_toast("Saved Successfully")
+
+
+    def import_from_file(self):
+        file_dialog = QFileDialog()
+        file_filter = "CSV File (*.csv)"
+        file_dialog.set_directory(settings.get("USER", "decks_directory", fallback="decks"))
+        file_paths = file_dialog.get_open_file_names(
+            caption="Select a Deck",
+            filter=file_filter
+        )
+
+        # Add all selected decks to the app_decks list
+        for file_path in file_paths[0]:
+            deck = utils.load_deck_from_csv(file_path)
+            if deck:
+                self.decks.append(deck)
+        self.reset_deck_list()
 
     def setup_menu(self):
         """ This method sets up the menu bar for the main window, using a dictionary to map menu names to actions. """

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import sys
 
 from PySide6.QtCore import Qt, Slot
-from PySide6.QtGui import QFont, QAction, QIcon
+from PySide6.QtGui import QFont, QAction
 from PySide6.QtWidgets import QApplication, QWidget, QVBoxLayout, QPushButton, QHBoxLayout, QDialog, QCheckBox, QLabel, \
     QMenuBar, QFileDialog
 # noinspection PyUnresolvedReferences
@@ -96,7 +96,6 @@ class MainWindow(QWidget):
 
         self.window_title = "JLPyT Flashcards"
         self.resize(1200, 700)
-        # self.palette = Qt.black
 
         self.show()
 
@@ -104,7 +103,6 @@ class MainWindow(QWidget):
         """ This method saves the decks to CSV files. """
         utils.save_decks_to_csv(app_decks, settings.get("USER", "decks_directory", fallback="decks"))
         self.toast.show_toast("Saved Successfully")
-
 
     def import_from_file(self):
         """ This method imports decks from a CSV file. """

--- a/main.py
+++ b/main.py
@@ -119,7 +119,7 @@ class MainWindow(QWidget):
         for file_path in file_paths[0]:
             deck = utils.load_deck_from_csv(file_path)
             if deck:
-
+                deck.name = file_path.split("/")[-1].split(".")[0]
                 self.decks.append(deck)
         self.reset_deck_list()
         self.toast.show_toast("Decks imported!")


### PR DESCRIPTION
### Closes #73 
- In the "File" menu, there is now an option to "Import From File", where a user can import a deck from a CSV file through a file dialog
- There is also a shortcut "Ctrl + I" to import from a file