### PR TITLE
Add remaining card counter

### DIFF
--- a/models/Deck.py
+++ b/models/Deck.py
@@ -29,7 +29,7 @@ class Deck:
         self.cards.append(card)
         self.is_modified = True
 
-    def get_filtered_cards(self, max_reviews: int, max_new: int):
+    def get_filtered_cards(self, max_reviews: int, max_new: int) -> (list, int):
         """
         Get a filtered list of cards based on the number of reviews and new cards.
         :param max_reviews: Maximum number of review cards
@@ -40,7 +40,11 @@ class Deck:
         review_cards = [card for card in self.cards if card.next_review_date.date() <= today and card.repetitions > 0]
         new_cards = [card for card in self.cards if card.next_review_date.date() >= today and card.repetitions == 0]
 
-        return review_cards[:max_reviews] + new_cards[:max_new]
+        review_cards = review_cards[:max_reviews]
+        new_cards = new_cards[:max_new]
+        num_of_cards = len(review_cards) + len(new_cards)
+
+        return review_cards + new_cards, num_of_cards
 
 
     def __str__(self):

--- a/widgets/CardWidget.py
+++ b/widgets/CardWidget.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from PySide6.QtWidgets import QLabel, QWidget, QPushButton, QVBoxLayout, QHBoxLayout
-from PySide6.QtCore import Qt, Slot
+from PySide6.QtCore import Qt, Slot, QObject, Signal
 
 # noinspection PyUnresolvedReference
 from __feature__ import snake_case, true_property
@@ -11,12 +11,17 @@ import utils
 from theme import palette, card_text_font
 
 
+class CardWidgetSignals(QObject):
+    card_passed = Signal()
+
 class CardWidget(QWidget):
     """
     This widget displays a flashcard for the user to review. The user can click a button to reveal the answer, and then
     click one of two buttons to indicate whether they passed or failed the card. The card is then updated with the
     appropriate review date and the next card is displayed.
     """
+
+    signals = CardWidgetSignals()
 
     def __init__(self, deck: Deck):
         """
@@ -104,6 +109,9 @@ class CardWidget(QWidget):
         """
         if not self.answer_shown or len(self.cards) == 0:
             return
+
+        if grade >= 3:
+            self.signals.card_passed.emit()
         self.cards[0].review(grade)
         # When a card is reviewed, the deck is modified, for the save function to know to save this particular deck
         self.deck.is_modified = True

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -51,6 +51,9 @@ class DeckListWidget(QWidget):
         self.stacked_widget.add_widget(self.deck_list_widget)
         self.layout.add_widget(self.stacked_widget)
 
+        self.remaining_card_count = QLabel()
+        self.layout.add_widget(self.remaining_card_count)
+
         utils.setup_shortcuts(self, shortcuts={
             "Esc": lambda: self.stacked_widget.set_current_widget(self.deck_list_widget)
         })
@@ -65,8 +68,10 @@ class DeckListWidget(QWidget):
         :return: None
         """
 
-        filtered_cards = deck.get_filtered_cards(self.max_reviews, self.max_new)
+        filtered_cards, num_of_cards = deck.get_filtered_cards(self.max_reviews, self.max_new)
         filtered_deck = Deck(deck.name, filtered_cards)
+
+        self.remaining_card_count.text = f"Remaining cards: {num_of_cards}"
         # Mark the deck as modified so that it is saved when the user exits the application
         deck.is_modified = True
         # Create a new widget to house the card widget

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -72,16 +72,22 @@ class DeckListWidget(QWidget):
         :return: None
         """
 
-        filtered_cards, self.remaining_card_count = deck.get_filtered_cards(self.max_reviews, self.max_new)
+        filtered_cards, num_cards_remaining = deck.get_filtered_cards(self.max_reviews, self.max_new)
         filtered_deck = Deck(deck.name, filtered_cards)
 
+        self.remaining_card_count = num_cards_remaining
         self.remaining_card_count_label.text = f'Remaining cards: <span style="color: {palette["primary_400"].name()}">{self.remaining_card_count}</span>'
+        self.remaining_card_count_label.show()
         # Mark the deck as modified so that it is saved when the user exits the application
         deck.is_modified = True
         # Create a new widget to house the card widget
         flashcard_layout_widget = QWidget()
         flashcard_layout = QVBoxLayout(flashcard_layout_widget)
         card_widget = CardWidget(filtered_deck)
+
+        # If a deck has already been viewed, disconnect the card_passed signal from the CardWidget and reconnect it to the handle_card_review method
+        if self.stacked_widget.count > 1:
+            card_widget.signals.card_passed.disconnect()
         card_widget.signals.card_passed.connect(self.handle_card_review)
 
         # Create a back button to return to the deck list

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -59,7 +59,7 @@ class DeckListWidget(QWidget):
         self.layout.add_widget(self.remaining_card_count_label)
 
         utils.setup_shortcuts(self, shortcuts={
-            "Esc": lambda: self.stacked_widget.set_current_widget(self.deck_list_widget)
+            "Esc": self.handle_escape
         })
 
         self.set_layout(self.layout)
@@ -93,7 +93,7 @@ class DeckListWidget(QWidget):
         # Create a back button to return to the deck list
         back_button = QPushButton("Back")
         back_button.tool_tip = "Shortcut: Esc"
-        back_button.clicked.connect(lambda: self.stacked_widget.set_current_widget(self.deck_list_widget))
+        back_button.clicked.connect(self.handle_escape)
 
         # Add the back button and card widget to the flashcard layout
         flashcard_layout.add_widget(back_button)
@@ -104,3 +104,7 @@ class DeckListWidget(QWidget):
     def handle_card_review(self):
         self.remaining_card_count -= 1
         self.remaining_card_count_label.text = f'Remaining cards: <span style="color: {palette["primary_400"].name()}">{self.remaining_card_count}</span>'
+
+    def handle_escape(self):
+        self.remaining_card_count_label.hide()
+        self.stacked_widget.set_current_widget(self.deck_list_widget)

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -27,6 +27,7 @@ class DeckListWidget(QWidget):
         self.settings = utils.load_config("settings.ini")
         self.max_reviews = self.settings.getint("USER", "daily_reviews_limit", fallback=100)
         self.max_new = self.settings.getint("USER", "new_card_limit", fallback=10)
+        self.remaining_card_count = None
 
         self.decks = decks
         self.layout = QVBoxLayout()
@@ -81,6 +82,7 @@ class DeckListWidget(QWidget):
         flashcard_layout_widget = QWidget()
         flashcard_layout = QVBoxLayout(flashcard_layout_widget)
         card_widget = CardWidget(filtered_deck)
+        card_widget.signals.card_passed.connect(self.handle_card_review)
 
         # Create a back button to return to the deck list
         back_button = QPushButton("Back")
@@ -92,3 +94,7 @@ class DeckListWidget(QWidget):
         flashcard_layout.add_widget(card_widget)
         self.stacked_widget.add_widget(flashcard_layout_widget)
         self.stacked_widget.set_current_widget(flashcard_layout_widget)
+
+    def handle_card_review(self):
+        self.remaining_card_count -= 1
+        self.remaining_card_count_label.text = f'Remaining cards: <span style="color: {palette["primary_400"].name()}">{self.remaining_card_count}</span>'

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -9,7 +9,7 @@ from __feature__ import snake_case, true_property
 import utils
 from models.Deck import Deck
 from widgets.CardWidget import CardWidget
-from theme import deck_list_item_font
+from theme import deck_list_item_font, palette, default_text_font
 
 
 class DeckListWidget(QWidget):
@@ -52,6 +52,9 @@ class DeckListWidget(QWidget):
         self.layout.add_widget(self.stacked_widget)
 
         self.remaining_card_count = QLabel()
+        self.remaining_card_count.alignment = Qt.AlignCenter
+        self.remaining_card_count.font = default_text_font
+        self.remaining_card_count.style_sheet = f"color: {palette['text'].name()}"
         self.layout.add_widget(self.remaining_card_count)
 
         utils.setup_shortcuts(self, shortcuts={

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -51,11 +51,11 @@ class DeckListWidget(QWidget):
         self.stacked_widget.add_widget(self.deck_list_widget)
         self.layout.add_widget(self.stacked_widget)
 
-        self.remaining_card_count = QLabel()
-        self.remaining_card_count.alignment = Qt.AlignCenter
-        self.remaining_card_count.font = default_text_font
-        self.remaining_card_count.style_sheet = f"color: {palette['text'].name()}"
-        self.layout.add_widget(self.remaining_card_count)
+        self.remaining_card_count_label = QLabel()
+        self.remaining_card_count_label.alignment = Qt.AlignCenter
+        self.remaining_card_count_label.font = default_text_font
+        self.remaining_card_count_label.style_sheet = f"color: {palette['text'].name()}"
+        self.layout.add_widget(self.remaining_card_count_label)
 
         utils.setup_shortcuts(self, shortcuts={
             "Esc": lambda: self.stacked_widget.set_current_widget(self.deck_list_widget)
@@ -71,10 +71,10 @@ class DeckListWidget(QWidget):
         :return: None
         """
 
-        filtered_cards, num_of_cards = deck.get_filtered_cards(self.max_reviews, self.max_new)
+        filtered_cards, self.remaining_card_count = deck.get_filtered_cards(self.max_reviews, self.max_new)
         filtered_deck = Deck(deck.name, filtered_cards)
 
-        self.remaining_card_count.text = f"Remaining cards: {num_of_cards}"
+        self.remaining_card_count_label.text = f'Remaining cards: <span style="color: {palette["primary_400"].name()}">{self.remaining_card_count}</span>'
         # Mark the deck as modified so that it is saved when the user exits the application
         deck.is_modified = True
         # Create a new widget to house the card widget


### PR DESCRIPTION
### Closes #71 
- Now each deck has a remaining card counter that updates when a user passes a card