### PR TITLE
Fix review issue

### DIFF
--- a/models/Deck.py
+++ b/models/Deck.py
@@ -19,6 +19,7 @@ class Deck:
         self.cards = cards
         self.is_modified = True
         # When a new deck is created, it is automatically modified, as it has not been saved yet
+        self.session_review_cards = 0
 
     def append_card(self, card: Flashcard) -> None:
         """
@@ -42,10 +43,22 @@ class Deck:
 
         review_cards = review_cards[:max_reviews]
         new_cards = new_cards[:max_new]
+        review_cards = review_cards[:max_reviews - self.session_review_cards]
+        new_cards = new_cards[:max_new - self.session_new_cards]
         num_of_cards = len(review_cards) + len(new_cards)
 
         return review_cards + new_cards, num_of_cards
 
+    def handle_card_review(self, is_new_card: bool):
+        """
+        Handle the review of a card.
+        :param is_new_card: True if the card is new, False otherwise
+        :return: None
+        """
+        if is_new_card:
+            self.session_new_cards += 1
+        else:
+            self.session_review_cards += 1
 
     def __str__(self):
         return f"Deck: {self.name}\nID: {self.id}\nCards: {self.cards}"

--- a/models/Deck.py
+++ b/models/Deck.py
@@ -20,6 +20,7 @@ class Deck:
         self.is_modified = True
         # When a new deck is created, it is automatically modified, as it has not been saved yet
         self.session_review_cards = 0
+        self.session_new_cards = 0
 
     def append_card(self, card: Flashcard) -> None:
         """
@@ -41,8 +42,6 @@ class Deck:
         review_cards = [card for card in self.cards if card.next_review_date.date() <= today and card.repetitions > 0]
         new_cards = [card for card in self.cards if card.next_review_date.date() >= today and card.repetitions == 0]
 
-        review_cards = review_cards[:max_reviews]
-        new_cards = new_cards[:max_new]
         review_cards = review_cards[:max_reviews - self.session_review_cards]
         new_cards = new_cards[:max_new - self.session_new_cards]
         num_of_cards = len(review_cards) + len(new_cards)

--- a/models/Deck.py
+++ b/models/Deck.py
@@ -38,9 +38,6 @@ class Deck:
         :param max_new: Maximum number of new cards
         :return: List of filtered cards, and the total number of cards that will be reviewed
         """
-        today = datetime.now().date()
-        review_cards = [card for card in self.cards if card.next_review_date.date() <= today and card.repetitions > 0]
-        new_cards = [card for card in self.cards if card.next_review_date.date() >= today and card.repetitions == 0]
         today = datetime.now()
         review_cards = [card for card in self.cards if card.next_review_date <= today and card.repetitions > 0]
         new_cards = [card for card in self.cards if card.next_review_date <= today and card.repetitions == 0]

--- a/models/Deck.py
+++ b/models/Deck.py
@@ -34,7 +34,7 @@ class Deck:
         Get a filtered list of cards based on the number of reviews and new cards.
         :param max_reviews: Maximum number of review cards
         :param max_new: Maximum number of new cards
-        :return: List of filtered cards
+        :return: List of filtered cards, and the total number of cards that will be reviewed
         """
         today = datetime.now().date()
         review_cards = [card for card in self.cards if card.next_review_date.date() <= today and card.repetitions > 0]

--- a/models/Deck.py
+++ b/models/Deck.py
@@ -41,6 +41,9 @@ class Deck:
         today = datetime.now().date()
         review_cards = [card for card in self.cards if card.next_review_date.date() <= today and card.repetitions > 0]
         new_cards = [card for card in self.cards if card.next_review_date.date() >= today and card.repetitions == 0]
+        today = datetime.now()
+        review_cards = [card for card in self.cards if card.next_review_date <= today and card.repetitions > 0]
+        new_cards = [card for card in self.cards if card.next_review_date <= today and card.repetitions == 0]
 
         review_cards = review_cards[:max_reviews - self.session_review_cards]
         new_cards = new_cards[:max_new - self.session_new_cards]

--- a/widgets/CardEditWidget.py
+++ b/widgets/CardEditWidget.py
@@ -9,10 +9,12 @@ from theme import default_text_font
 
 
 class CardEditSignals(QObject):
+    """ This class manages the signals for the CardEditWidget. """
     card_edited = Signal(Flashcard, Flashcard)
 
 
 class CardEditWidget(QWidget):
+    """ This class manages the card editor in the DeckListWidget. """
     signals = CardEditSignals()
 
     def __init__(self, card: Flashcard = None) -> None:
@@ -52,6 +54,7 @@ class CardEditWidget(QWidget):
         # self.show()
 
     def load_card(self):
+        """ This method sets the card's front, back, and tags inputs. """
         self.front_input.set_text(self.card.question)
         self.back_input.set_text(self.card.answer)
         # example: "tag1 tag2 tag3"
@@ -59,6 +62,7 @@ class CardEditWidget(QWidget):
 
     @Slot()
     def save_card(self):
+        """ This method sends the updated card to the DeckListWidget. """
         old_card = Flashcard(question=self.card.question, answer=self.card.answer, tags=self.card.tags)
         self.card.question = self.front_input.plain_text
         self.card.answer = self.back_input.plain_text

--- a/widgets/CardWidget.py
+++ b/widgets/CardWidget.py
@@ -8,11 +8,12 @@ from __feature__ import snake_case, true_property
 
 from models.Deck import Deck
 import utils
+from models.Flashcard import Flashcard
 from theme import card_text_font, PaletteFactory, palettes
 
 
 class CardWidgetSignals(QObject):
-    card_passed = Signal()
+    card_passed = Signal(Flashcard)
 
 
 class CardWidget(QWidget):
@@ -115,7 +116,7 @@ class CardWidget(QWidget):
             return
 
         if grade >= 3:
-            self.signals.card_passed.emit()
+            self.signals.card_passed.emit(self.cards[0])
         self.cards[0].review(grade)
         # When a card is reviewed, the deck is modified, for the save function to know to save this particular deck
         self.deck.is_modified = True

--- a/widgets/DeckListWidget.py
+++ b/widgets/DeckListWidget.py
@@ -8,6 +8,7 @@ from __feature__ import snake_case, true_property
 
 import utils
 from models.Deck import Deck
+from models.Flashcard import Flashcard
 from widgets.CardWidget import CardWidget
 from theme import deck_list_item_font, default_text_font, palettes
 
@@ -31,6 +32,7 @@ class DeckListWidget(QWidget):
         self.remaining_card_count = None
 
         self.decks = decks
+        self.current_deck = None
         self.layout = QVBoxLayout()
         self.deck_list_widget = QWidget()
         self.deck_list_widget.font = deck_list_item_font
@@ -74,6 +76,7 @@ class DeckListWidget(QWidget):
         """
         palette = palettes[self.settings.get("USER", "theme", fallback="dark_blue")]
 
+        self.current_deck = deck
         filtered_cards, num_cards_remaining = deck.get_filtered_cards(self.max_reviews, self.max_new)
         filtered_deck = Deck(deck.name, filtered_cards)
 
@@ -103,10 +106,12 @@ class DeckListWidget(QWidget):
         self.stacked_widget.add_widget(flashcard_layout_widget)
         self.stacked_widget.set_current_widget(flashcard_layout_widget)
 
-    def handle_card_review(self):
+    @Slot(Flashcard)
+    def handle_card_review(self, card: Flashcard):
         palette = palettes[self.settings.get("USER", "theme", fallback="dark_blue")]
         self.remaining_card_count -= 1
         self.remaining_card_count_label.text = f'Remaining cards: <span style="color: {palette["primary_400"].name()}">{self.remaining_card_count}</span>'
+        self.current_deck.handle_card_review(card.repetitions == 0)
 
     def handle_escape(self):
         self.remaining_card_count_label.hide()

--- a/widgets/SettingsDialog.py
+++ b/widgets/SettingsDialog.py
@@ -79,6 +79,10 @@ class SettingsDialog(QDialog):
         self.save_button.clicked.connect(self.save_settings)
         self.layout.add_widget(self.save_button)
 
+        self.warning_text = QLabel("Note: Changes to review counts will take effect after restarting the application.")
+        self.warning_text.font = default_text_font
+        self.layout.add_widget(self.warning_text)
+
         self.resize(700, 250)
         self.set_layout(self.layout)
 


### PR DESCRIPTION
### Closes #81 
- The number of reviews for review and new cards is monitored by the Deck class
- When a user reviews cards, the counters are updated and they won't be able to review more cards until restarting the application* (see below)
- There is now a warning in the settings that updating the max number of reviews won't be reflected in the deck list until the program has been restarted.

* #83 Should fix the problem of reviews updating at the start of a new day. Ideally, we'll keep track of the last review time in the settings, and then when we're refreshing the decklist, we check that time against the current time. If a new day has started, then we need to reset the decks' counters so that the user can leave the program open however long they want and still be able to review